### PR TITLE
Handle global namespace properly

### DIFF
--- a/csharp/PythonNetStubGenerator/PythonTypes.cs
+++ b/csharp/PythonNetStubGenerator/PythonTypes.cs
@@ -84,9 +84,11 @@ namespace PythonNetStubGenerator
 
         public static (string nameSpace, List<Type> types) RemoveDirtyNamespace()
         {
-            var key = DirtyNamespaces.FirstOrDefault();
+            if (DirtyNamespaces.Count() == 0)
+                return ("", new List<Type>());
+
+            var key = DirtyNamespaces.First();
             DirtyNamespaces.Remove(key);
-            if (key == null) return (null, new List<Type>());
             var results = AllExportedTypes.Where(it => it.Namespace == key).ToList();
             return (key, results);
         }

--- a/csharp/PythonNetStubGenerator/StubBuilder.cs
+++ b/csharp/PythonNetStubGenerator/StubBuilder.cs
@@ -56,7 +56,9 @@ namespace PythonNetStubGenerator
             while (true)
             {
                 var (nameSpace, types) = PythonTypes.RemoveDirtyNamespace();
-                if (nameSpace == null) break;
+
+                if (nameSpace == "")
+                    break;
 
                 // generate stubs for each type
                 WriteStub(destPath, nameSpace, types);
@@ -71,7 +73,23 @@ namespace PythonNetStubGenerator
             // sort the stub list so we get consistent output over time
             var orderedTypes = stubTypes.OrderBy(it => it.Name);
 
-            var path = nameSpace.Split('.').Aggregate(rootDirectory.FullName, Path.Combine);
+            string path;
+
+            if (nameSpace is null)
+            {
+                path = "global_";
+            }
+            else
+            {
+                var split = nameSpace.Split('.');
+
+                if (split[0] == "global_")
+                {
+                    throw new InvalidDataException("The namespace \"global_\" is reserved.");
+                }
+
+                path = split.Aggregate(rootDirectory.FullName, Path.Combine);
+            }
 
             if (!Directory.Exists(path))
                 Directory.CreateDirectory(path);

--- a/csharp/PythonNetStubGenerator/StubBuilder.cs
+++ b/csharp/PythonNetStubGenerator/StubBuilder.cs
@@ -1,15 +1,15 @@
 ﻿using System;
-using System.Reflection;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 
 namespace PythonNetStubGenerator
 {
     public static class StubBuilder
     {
         private static HashSet<DirectoryInfo> SearchPaths { get; } = new HashSet<DirectoryInfo>();
-        
+
         public static DirectoryInfo BuildAssemblyStubs(DirectoryInfo destPath, FileInfo[] targetAssemblyPaths, DirectoryInfo[] searchPaths = null)
         {
             // prepare resolver
@@ -21,7 +21,7 @@ namespace PythonNetStubGenerator
             {
                 var assemblyToStub = Assembly.LoadFrom(targetAssemblyPath.FullName);
                 SearchPaths.Add(targetAssemblyPath.Directory);
-                
+
                 if (searchPaths != null)
                     foreach (var path in SearchPaths)
                         SearchPaths.Add(path);
@@ -29,7 +29,7 @@ namespace PythonNetStubGenerator
                 Console.WriteLine($"Generating Assembly: {assemblyToStub.FullName}");
                 foreach (var exportedType in assemblyToStub.GetExportedTypes())
                 {
-                    if(!exportedType.IsVisible) continue;
+                    if (!exportedType.IsVisible) continue;
                     PythonTypes.AddDependency(exportedType);
                 }
             }
@@ -40,7 +40,7 @@ namespace PythonNetStubGenerator
 
             foreach (var exportedType in typeAssembly.GetExportedTypes())
             {
-                if(!exportedType.IsVisible) continue;
+                if (!exportedType.IsVisible) continue;
                 PythonTypes.AddDependency(exportedType);
             }
 
@@ -48,7 +48,7 @@ namespace PythonNetStubGenerator
             Console.WriteLine($"Generating Built-in Assembly: {consoleAssembly.FullName}");
             foreach (var exportedType in consoleAssembly.GetExportedTypes())
             {
-                if(!exportedType.IsVisible) continue;
+                if (!exportedType.IsVisible) continue;
                 PythonTypes.AddDependency(exportedType);
             }
 


### PR DESCRIPTION
### Abstract

This PR enables `StubBuilder` to handle types in global namespace. Before this PR, it stopped generating stub files silently.

### Digest of changes

Types in the global namespace are stored `global_/__init__.pyi`.

### Notes

It is still not clear how the types in the global namespace can be accessed from Python.
