### PR TITLE
Modernise .NET and packages

### DIFF
--- a/csharp/PythonNetStubGenerator/PythonNetStubGenerator.csproj
+++ b/csharp/PythonNetStubGenerator/PythonNetStubGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>PythonNetStubGenerator</PackageId>

--- a/csharp/PythonNetStubTask/PythonNetStubTask.csproj
+++ b/csharp/PythonNetStubTask/PythonNetStubTask.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.3" />
+		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/csharp/PythonNetStubTask/PythonNetStubTask.csproj
+++ b/csharp/PythonNetStubTask/PythonNetStubTask.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>netstandard2.1</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/csharp/PythonNetStubTool/Program.cs
+++ b/csharp/PythonNetStubTool/Program.cs
@@ -1,16 +1,57 @@
-﻿using PythonNetStubGenerator;
+﻿using System.CommandLine;
+using System.CommandLine.Parsing;
+using PythonNetStubGenerator;
 
 namespace PythonNetStubTool
 {
     static class Program
     {
+        static int Main(string[] args)
+        {
+            Option<DirectoryInfo> destPathOption = new("--dest-path")
+            {
+                Description = "Path to save the stubs to.",
+                Required = true
+            };
+
+            Option<string> targetDllsOption = new("--target-dlls")
+            {
+                Description = "Target DLLs.",
+                Required = true
+            };
+
+            Option<DirectoryInfo[]> searchPathsOption = new("--search-paths")
+            {
+                Description = "Path to search for referenced assemblies.",
+                Arity = ArgumentArity.OneOrMore,
+                Required = false
+            };
+
+            RootCommand rootCommand = new("PythonNet Stub Generator Tool");
+            rootCommand.Options.Add(destPathOption);
+            rootCommand.Options.Add(targetDllsOption);
+            rootCommand.Options.Add(searchPathsOption);
+
+            rootCommand.SetAction(parseResult =>
+            {
+                DirectoryInfo destPath = parseResult.GetValue(destPathOption)!;
+                string targetDlls = parseResult.GetValue(targetDllsOption)!;
+                DirectoryInfo[]? searchPaths = parseResult.GetValue(searchPathsOption);
+
+                return Run(destPath, targetDlls, searchPaths);
+            });
+
+            ParseResult parseResult = rootCommand.Parse(args);
+            return parseResult.Invoke();
+        }
+
         /// <summary>
         /// Creates stubs for Python.Net
         /// </summary>
         /// <param name="destPath">Path to save the subs to.</param>
         /// <param name="searchPaths">Path to search for referenced assemblies</param>
         /// <param name="targetDlls">Target DLLsz</param>
-        static int Main(
+        static int Run(
             DirectoryInfo destPath,
             string targetDlls,
             DirectoryInfo[]? searchPaths = null

--- a/csharp/PythonNetStubTool/PythonNetStubGenerator.Tool.csproj
+++ b/csharp/PythonNetStubTool/PythonNetStubGenerator.Tool.csproj
@@ -1,43 +1,43 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <PackAsTool>true</PackAsTool>
-    <ToolCommandName>GeneratePythonNetStubs</ToolCommandName>
-    <PackageOutputPath>./nupkg</PackageOutputPath>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <PackageId>PythonNetStubGenerator.Tool</PackageId>
-    <Authors>MHDante</Authors>
-    <Company>Transitional Forms Inc.</Company>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <RepositoryUrl>https://github.com/MHDante/pythonnet-stub-generator</RepositoryUrl>
-    <PackageTags>python.net</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.1</Version>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
 		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<PackAsTool>true</PackAsTool>
+		<ToolCommandName>GeneratePythonNetStubs</ToolCommandName>
+		<PackageOutputPath>./nupkg</PackageOutputPath>
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<PackageId>PythonNetStubGenerator.Tool</PackageId>
+		<Authors>MHDante</Authors>
+		<Company>Transitional Forms Inc.</Company>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<RepositoryUrl>https://github.com/MHDante/pythonnet-stub-generator</RepositoryUrl>
+		<PackageTags>python.net</PackageTags>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<Version>1.2.1</Version>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Remove="nupkg\**" />
-    <EmbeddedResource Remove="nupkg\**" />
-    <None Remove="nupkg\**" />
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Remove="nupkg\**" />
+		<EmbeddedResource Remove="nupkg\**" />
+		<None Remove="nupkg\**" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\..\README.md">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+	</ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.4.0-alpha.22114.1" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\PythonNetStubGenerator\PythonNetStubGenerator.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\PythonNetStubGenerator\PythonNetStubGenerator.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/csharp/PythonNetStubTool/PythonNetStubGenerator.Tool.csproj
+++ b/csharp/PythonNetStubTool/PythonNetStubGenerator.Tool.csproj
@@ -32,9 +32,9 @@
 		</None>
 	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.4.0-alpha.22114.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="System.CommandLine" Version="2.0.0" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\PythonNetStubGenerator\PythonNetStubGenerator.csproj" />

--- a/csharp/PythonNetStubTool/PythonNetStubGenerator.Tool.csproj
+++ b/csharp/PythonNetStubTool/PythonNetStubGenerator.Tool.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>
@@ -18,6 +17,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Version>1.2.1</Version>
   </PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
 
   <ItemGroup>
     <Compile Remove="nupkg\**" />


### PR DESCRIPTION
### Digest of changes

* Update .NET runtime: 6 to 8
* Update Microsoft.Build.Utilities.Core: 17.8.3 to 18.0.2
* Replace deprecated package: System.CommandLine.DragonFruit with System.CommandLine
