### PR TITLE
Add prefix "Static" to static classes

### DIFF
--- a/csharp/PythonNetStubGenerator/StaticClassScope.cs
+++ b/csharp/PythonNetStubGenerator/StaticClassScope.cs
@@ -6,10 +6,10 @@ using System.Text;
 
 namespace PythonNetStubGenerator
 {
-    public class ClassScope : IDisposable
+    public class StaticClassScope : IDisposable
     {
-        private static readonly List<ClassScope> ClassScopes = new List<ClassScope>();
-        public static ClassScope Current => ClassScopes.LastOrDefault();
+        private static readonly List<StaticClassScope> ClassScopes = new List<StaticClassScope>();
+        public static StaticClassScope Current => ClassScopes.LastOrDefault();
         public string PythonClass
         {
             get;
@@ -32,7 +32,7 @@ namespace PythonNetStubGenerator
             get; set;
         }
 
-        public ClassScope(string pythonClass, IEnumerable<Type> newGenerics, bool shouldShadowGenerics)
+        public StaticClassScope(string pythonClass, IEnumerable<Type> newGenerics, bool shouldShadowGenerics)
         {
             Generics = newGenerics.ToArray();
             ShouldShadowGenerics = shouldShadowGenerics;

--- a/csharp/PythonNetStubGenerator/StaticPythonTypes.cs
+++ b/csharp/PythonNetStubGenerator/StaticPythonTypes.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 
 namespace PythonNetStubGenerator
 {
-    public static class PythonTypes
+    public static class StaticPythonTypes
     {
         private static readonly HashSet<Type> AllExportedTypes = new HashSet<Type>();
         private static readonly HashSet<string> DirtyNamespaces = new HashSet<string>();
@@ -237,7 +237,7 @@ namespace PythonNetStubGenerator
                 return $"{s}.";
 
             var cleanName = type.CleanName();
-            if (SymbolScope.Scopes.Any(it => it.HasConflict(cleanName, type.Namespace)))
+            if (StaticSymbolScope.Scopes.Any(it => it.HasConflict(cleanName, type.Namespace)))
             {
                 AddNamespaceDependency(type.Namespace);
                 return $"{type.Namespace}.";
@@ -258,7 +258,7 @@ namespace PythonNetStubGenerator
 
         private static string GetGenericTypeParameterName(Type t)
         {
-            var currentScope = ClassScope.Current;
+            var currentScope = StaticClassScope.Current;
 
             var method = t.DeclaringMethod;
             var declType = t.DeclaringType;

--- a/csharp/PythonNetStubGenerator/StaticStubBuilder.cs
+++ b/csharp/PythonNetStubGenerator/StaticStubBuilder.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 
 namespace PythonNetStubGenerator
 {
-    public static class StubBuilder
+    public static class StaticStubBuilder
     {
         private static HashSet<DirectoryInfo> SearchPaths { get; } = new HashSet<DirectoryInfo>();
 
@@ -31,7 +31,7 @@ namespace PythonNetStubGenerator
                 {
                     if (!exportedType.IsVisible)
                         continue;
-                    PythonTypes.AddDependency(exportedType);
+                    StaticPythonTypes.AddDependency(exportedType);
                 }
             }
 
@@ -43,7 +43,7 @@ namespace PythonNetStubGenerator
             {
                 if (!exportedType.IsVisible)
                     continue;
-                PythonTypes.AddDependency(exportedType);
+                StaticPythonTypes.AddDependency(exportedType);
             }
 
             var consoleAssembly = typeof(Console).Assembly;
@@ -52,13 +52,13 @@ namespace PythonNetStubGenerator
             {
                 if (!exportedType.IsVisible)
                     continue;
-                PythonTypes.AddDependency(exportedType);
+                StaticPythonTypes.AddDependency(exportedType);
             }
 
 
             while (true)
             {
-                var (nameSpace, types) = PythonTypes.RemoveDirtyNamespace();
+                var (nameSpace, types) = StaticPythonTypes.RemoveDirtyNamespace();
 
                 if (nameSpace == "")
                     break;
@@ -99,9 +99,9 @@ namespace PythonNetStubGenerator
 
             path = Path.Combine(path, "__init__.pyi");
 
-            PythonTypes.ClearCurrent();
+            StaticPythonTypes.ClearCurrent();
 
-            var stubText = StubWriter.GetStub(nameSpace, orderedTypes);
+            var stubText = StaticStubWriter.GetStub(nameSpace, orderedTypes);
 
 
             File.WriteAllText(path, stubText);

--- a/csharp/PythonNetStubGenerator/StaticSymbolScope.cs
+++ b/csharp/PythonNetStubGenerator/StaticSymbolScope.cs
@@ -3,14 +3,14 @@ using System.Collections.Generic;
 
 namespace PythonNetStubGenerator
 {
-    public class SymbolScope : IDisposable
+    public class StaticSymbolScope : IDisposable
     {
 
         public readonly List<string> ReservedSymbols;
-        public static readonly List<SymbolScope> Scopes = new List<SymbolScope>();
+        public static readonly List<StaticSymbolScope> Scopes = new List<StaticSymbolScope>();
         public readonly string Namespace;
 
-        public SymbolScope(IEnumerable<string> reservedSymbols, string nameSpace)
+        public StaticSymbolScope(IEnumerable<string> reservedSymbols, string nameSpace)
         {
             Namespace = nameSpace;
             ReservedSymbols = new List<string>(reservedSymbols);

--- a/csharp/PythonNetStubTask/PythonNetStubTask.cs
+++ b/csharp/PythonNetStubTask/PythonNetStubTask.cs
@@ -35,7 +35,7 @@ namespace PythonNetStubTask
             try
             {
                 Log.LogMessage(MessageImportance.High, "Generating Stubs for " + destPath.FullName);
-                StubBuilder.BuildAssemblyStubs(destPath, sourceDlls, directoryPaths);
+                StaticStubBuilder.BuildAssemblyStubs(destPath, sourceDlls, directoryPaths);
                 Log.LogMessage(MessageImportance.High, "Done");
 
             }

--- a/csharp/PythonNetStubTool/Program.cs
+++ b/csharp/PythonNetStubTool/Program.cs
@@ -80,7 +80,7 @@ namespace PythonNetStubTool
 
             try
             {
-                var dest = StubBuilder.BuildAssemblyStubs(destPath, infos.ToArray(), searchPaths);
+                var dest = StaticStubBuilder.BuildAssemblyStubs(destPath, infos.ToArray(), searchPaths);
                 Console.WriteLine($"stubs saved to {dest}");
                 return 0;
             }


### PR DESCRIPTION
The prefix `Static` is added to each static class.

### Notes

Currently, many classes are implemented as static classes and have side effects. They should be implemented as non-static classes and have their own context with no side effects.

That would make debugging and extending classes easier.
